### PR TITLE
Change method parseText

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -120,7 +120,6 @@ const main = module.exports = async (linkOrId, options, rt = 3) => {
       thumbnail,
       url: `${BASE_PLIST_URL}list=${plistId}`,
       title: UTIL.parseText(info.title),
-      description: UTIL.parseText(info.description),
       total_items: UTIL.parseNumFromText(info.stats[0]),
       views: info.stats.length === 3 ? UTIL.parseNumFromText(info.stats[1]) : 0,
     };

--- a/lib/main.js
+++ b/lib/main.js
@@ -120,6 +120,7 @@ const main = module.exports = async (linkOrId, options, rt = 3) => {
       thumbnail,
       url: `${BASE_PLIST_URL}list=${plistId}`,
       title: UTIL.parseText(info.title),
+      description: UTIL.parseText(info.description),
       total_items: UTIL.parseNumFromText(info.stats[0]),
       views: info.stats.length === 3 ? UTIL.parseNumFromText(info.stats[1]) : 0,
     };

--- a/lib/util.js
+++ b/lib/util.js
@@ -48,7 +48,11 @@ exports.parseBody = (body, options = {}) => {
 };
 
 // Parsing utility
-const parseText = exports.parseText = txt => txt.simpleText || txt.runs.map(a => a.text).join('');
+const parseText = exports.parseText = txt => {
+  if (txt.simpleText) return txt.simpleText;
+  if (txt.runs) return txt.runs.map(a => a.text).join('');
+  return '';
+};
 
 exports.parseNumFromText = txt => Number(parseText(txt).replace(/\D+/g, ''));
 


### PR DESCRIPTION
After PR https://github.com/distubejs/ytpl/pull/7 we have an error:
```
Error: TypeError: Cannot read properties of undefined (reading 'map')
```

From function:
```ts
const parseText = exports.parseText = txt => txt.simpleText || txt.runs.map(a => a.text).join('');
```

Due to changes in this PR
https://github.com/distubejs/ytpl/blob/19389434d88853786801c8459800d6f48df9f749/lib/main.js#L123

And we have two ways:
1. Roll back these breaking changes (because there is no description at all in the dump)
2. Add optional chaining

I prefer the first option, but decide for yourself.